### PR TITLE
Add Method of retrieving customer by Email

### DIFF
--- a/Checkout.ApiClient.Net40/ApiServices/Customers/CustomerService.cs
+++ b/Checkout.ApiClient.Net40/ApiServices/Customers/CustomerService.cs
@@ -24,13 +24,18 @@ public class CustomerService  {
         return new ApiHttpClient().DeleteRequest<OkResponse>(deleteCustomerUri, AppSettings.SecretKey);
     }
 
-    public HttpResponse<Customer> GetCustomer(string customerId)
+    public HttpResponse<Customer> GetCustomerById(string customerId)
     {
         var getCustomerUri = string.Format(ApiUrls.Customer, customerId);
         return new ApiHttpClient().GetRequest<Customer>(getCustomerUri, AppSettings.SecretKey);
     }
 
-    public HttpResponse<CustomerList> GetCustomerList(CustomerGetList request)
+        public HttpResponse<Customer> GetCustomerByEmail(string customerEmail)
+        {
+            var getCustomerUri = string.Format(ApiUrls.CustomerByEmail, customerEmail);
+            return new ApiHttpClient().GetRequest<Customer>(getCustomerUri, AppSettings.SecretKey);
+        }
+        public HttpResponse<CustomerList> GetCustomerList(CustomerGetList request)
     {
         var getCustomerListUri = ApiUrls.Customers;
 

--- a/Checkout.ApiClient.Net40/ApiServices/Customers/CustomerService.cs
+++ b/Checkout.ApiClient.Net40/ApiServices/Customers/CustomerService.cs
@@ -24,7 +24,7 @@ public class CustomerService  {
         return new ApiHttpClient().DeleteRequest<OkResponse>(deleteCustomerUri, AppSettings.SecretKey);
     }
 
-    public HttpResponse<Customer> GetCustomerById(string customerId)
+    public HttpResponse<Customer> GetCustomer(string customerId)
     {
         var getCustomerUri = string.Format(ApiUrls.Customer, customerId);
         return new ApiHttpClient().GetRequest<Customer>(getCustomerUri, AppSettings.SecretKey);

--- a/Checkout.ApiClient.Net40/Helpers/ApiUrls.cs
+++ b/Checkout.ApiClient.Net40/Helpers/ApiUrls.cs
@@ -200,6 +200,14 @@
             }
         }
 
+        public static string CustomerByEmail
+        {
+            get
+            {
+                return _customerApiUri ?? (_customerApiUri = string.Concat(AppSettings.BaseApiUri, "/customers?email={0}"));
+            }
+        }
+
         public static string Cards
         {
             get

--- a/Checkout.ApiClient.Net40/Properties/AssemblyInfo.cs
+++ b/Checkout.ApiClient.Net40/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.10")]
-[assembly: AssemblyFileVersion("1.3.0.10")]
+[assembly: AssemblyVersion("1.3.0.11")]
+[assembly: AssemblyFileVersion("1.3.0.11")]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/Checkout.ApiClient.Net45/ApiServices/Customers/CustomerService.cs
+++ b/Checkout.ApiClient.Net45/ApiServices/Customers/CustomerService.cs
@@ -24,9 +24,15 @@ public class CustomerService  {
         return new ApiHttpClient().DeleteRequest<OkResponse>(deleteCustomerUri, AppSettings.SecretKey);
     }
 
-    public HttpResponse<Customer> GetCustomer(string customerId)
+    public HttpResponse<Customer> GetCustomerById(string customerId)
     {
         var getCustomerUri = string.Format(ApiUrls.Customer, customerId);
+        return new ApiHttpClient().GetRequest<Customer>(getCustomerUri, AppSettings.SecretKey);
+    }
+
+    public HttpResponse<Customer> GetCustomerByEmail(string customerEmail)
+    {
+        var getCustomerUri = string.Format(ApiUrls.CustomerByEmail, customerEmail);
         return new ApiHttpClient().GetRequest<Customer>(getCustomerUri, AppSettings.SecretKey);
     }
 

--- a/Checkout.ApiClient.Net45/ApiServices/Customers/CustomerService.cs
+++ b/Checkout.ApiClient.Net45/ApiServices/Customers/CustomerService.cs
@@ -24,7 +24,7 @@ public class CustomerService  {
         return new ApiHttpClient().DeleteRequest<OkResponse>(deleteCustomerUri, AppSettings.SecretKey);
     }
 
-    public HttpResponse<Customer> GetCustomerById(string customerId)
+    public HttpResponse<Customer> GetCustomer(string customerId)
     {
         var getCustomerUri = string.Format(ApiUrls.Customer, customerId);
         return new ApiHttpClient().GetRequest<Customer>(getCustomerUri, AppSettings.SecretKey);

--- a/Checkout.ApiClient.Net45/Helpers/ApiUrls.cs
+++ b/Checkout.ApiClient.Net45/Helpers/ApiUrls.cs
@@ -133,6 +133,9 @@
         public static string Customer
             => _customerApiUri ?? (_customerApiUri = string.Concat(AppSettings.BaseApiUri, "/customers/{0}"));
 
+        public static string CustomerByEmail
+            => _customerApiUri ?? (_customerApiUri = string.Concat(AppSettings.BaseApiUri, "/customers?email={0}"));
+
         public static string Cards
             => _cardsApiUri ?? (_cardsApiUri = string.Concat(AppSettings.BaseApiUri, "/customers/{0}/cards"));
 

--- a/Checkout.ApiClient.Net45/Properties/AssemblyInfo.cs
+++ b/Checkout.ApiClient.Net45/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Resources;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.10")]
-[assembly: AssemblyFileVersion("1.3.0.10")]
+[assembly: AssemblyVersion("1.3.0.11")]
+[assembly: AssemblyFileVersion("1.3.0.11")]
 [assembly: NeutralResourcesLanguageAttribute("en")]

--- a/Checkout.ApiClient.Tests/CustomerService/CustomerServiceTests.cs
+++ b/Checkout.ApiClient.Tests/CustomerService/CustomerServiceTests.cs
@@ -49,12 +49,27 @@ namespace Tests
         }
 
         [Test]
-        public void GetCustomer()
+        public void GetCustomerById()
         {
             var customerCreateModel = TestHelper.GetCustomerCreateModelWithCard();
             var customer = CheckoutClient.CustomerService.CreateCustomer(customerCreateModel).Model;
 
-            var response = CheckoutClient.CustomerService.GetCustomer(customer.Id);
+            var response = CheckoutClient.CustomerService.GetCustomerById(customer.Id);
+
+            response.Should().NotBeNull();
+            response.HttpStatusCode.Should().Be(HttpStatusCode.OK);
+            response.Model.Id.Should().Be(customer.Id);
+            response.Model.Id.Should().StartWith("cust_");
+            customer.ShouldBeEquivalentTo(response.Model);
+        }
+
+        [Test]
+        public void GetCustomerByEmail()
+        {
+            var customerCreateModel = TestHelper.GetCustomerCreateModelWithCard();
+            var customer = CheckoutClient.CustomerService.CreateCustomer(customerCreateModel).Model;
+
+            var response = CheckoutClient.CustomerService.GetCustomerByEmail(customer.Email);
 
             response.Should().NotBeNull();
             response.HttpStatusCode.Should().Be(HttpStatusCode.OK);

--- a/Checkout.ApiClient.Tests/CustomerService/CustomerServiceTests.cs
+++ b/Checkout.ApiClient.Tests/CustomerService/CustomerServiceTests.cs
@@ -54,7 +54,7 @@ namespace Tests
             var customerCreateModel = TestHelper.GetCustomerCreateModelWithCard();
             var customer = CheckoutClient.CustomerService.CreateCustomer(customerCreateModel).Model;
 
-            var response = CheckoutClient.CustomerService.GetCustomerById(customer.Id);
+            var response = CheckoutClient.CustomerService.GetCustomer(customer.Id);
 
             response.Should().NotBeNull();
             response.HttpStatusCode.Should().Be(HttpStatusCode.OK);


### PR DESCRIPTION
Current GetCustomer(string customerId) method has confusing signature. It allows retrieving customer not only supplying customerId ("cust_{guid}") but also supports email as a parameter. 

This kind of usage has issue when supplying email with '+' symbol in it e.g. "test+mail@gmail.com" which is actually valid email. Documentation [states](https://docs.checkout.com/docs/get-customer#section-the-request) that to workaround this issue it's possible to supply request in the following format:

> /customers?email=elizabeth+seymore@domain.com

Introduced method 
GetCustomerByEmail(string customerEmail) employs this workaround and introducces mor clarity in API interface.